### PR TITLE
Rails 3 routing DSL to prevent warnings

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
-Rails.application.routes.draw do |map|
+Rails.application.routes.draw do
   match ":controller/render_event_response", :to => "#render_event_response", :as => "apotomo_event"
 end


### PR DESCRIPTION
Hey Nick

this is just a minor fix to prevent Rails 3 from issuing deprecation warnings.

Cheers,
-- Yves
