### PR TITLE
Escape javascript using ActionView::Helpers::JavaScriptHelper

### DIFF
--- a/lib/apotomo/javascript_generator.rb
+++ b/lib/apotomo/javascript_generator.rb
@@ -1,3 +1,5 @@
+require 'action_view/helpers/javascript_helper'
+
 module Apotomo
   class JavascriptGenerator
     def initialize(framework)
@@ -9,21 +11,11 @@ module Apotomo
       "#{javascript}"
     end
     
-    # Copied from ActionView::Helpers::JavascriptHelper.
-    JS_ESCAPE_MAP = {
-      '\\'    => '\\\\',
-      '</'    => '<\/',
-      "\r\n"  => '\n',
-      "\n"    => '\n',
-      "\r"    => '\n',
-      '"'     => '\\"',
-      "'"     => "\\'" }
+    JS_ESCAPER = Object.new.extend(::ActionView::Helpers::JavaScriptHelper)
 
     # Escape carrier returns and single and double quotes for JavaScript segments.
     def self.escape(javascript)
-      return javascript.gsub(/(\\|<\/|\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] } if javascript
-      
-      ''
+      JS_ESCAPER.escape_javascript(javascript)
     end
     
     def escape(javascript)


### PR DESCRIPTION
Escape javascript using ActionView::Helpers::JavaScriptHelper to avoid code duplication and differences between rails versions. [#24 state:resolved]

I tested it against
3.0.9.rc3
3.0.8
3.0.7
3.0.3.

It doesn't work for 3.0.8 but this is a quote from rails-core:
`If you’re using js views and partial html replacements, Rails 3.0.8
was totally broken. Right after the 3.0.8 release, 3.0.9rc1 was
released which partially addresses the problem`
so I don't think we need to support it.

Everything else works fine.
