### PR TITLE
Define generators for Rails's assets pipeline

### DIFF
--- a/lib/generators/apotomo/widget_generator.rb
+++ b/lib/generators/apotomo/widget_generator.rb
@@ -7,21 +7,33 @@ module Apotomo
       def base_path
         File.join('app/widgets', class_path, file_name)
       end
+
+      def js_path
+        File.join('app/assets/javascripts/widgets', class_path, file_name)
+      end
+
+      def css_path
+        File.join('app/assets/stylesheets/widgets', class_path, file_name)
+      end
     end
-    
+
     class WidgetGenerator < ::Cells::Generators::Base
       include BasePathMethods
-      
+
       source_root File.expand_path('../../templates', __FILE__)
-      
+
       hook_for(:template_engine)
       hook_for(:test_framework)  # TODO: implement rspec-apotomo.
-      
+
       check_class_collision :suffix => "Widget"
-      
-      
+
       def create_cell_file
         template 'widget.rb', "#{base_path}_widget.rb"
+      end
+
+      def create_assets_files
+        template 'widget.coffee', "#{js_path}_widget.coffee"
+        template 'widget.css', "#{css_path}_widget.css"
       end
     end
   end

--- a/lib/generators/templates/widget.coffee
+++ b/lib/generators/templates/widget.coffee
@@ -1,0 +1,1 @@
+# Define your coffeescript code for the <%= class_name %> widget

--- a/lib/generators/templates/widget.css
+++ b/lib/generators/templates/widget.css
@@ -1,0 +1,1 @@
+/*Define your css code for the <%= class_name %> widget*/

--- a/test/rails/widget_generator_test.rb
+++ b/test/rails/widget_generator_test.rb
@@ -5,13 +5,13 @@ class WidgetGeneratorTest < Rails::Generators::TestCase
   destination File.join(Rails.root, "tmp")
   setup :prepare_destination
   tests ::Apotomo::Generators::WidgetGenerator
-   
+
   context "Running rails g apotomo::widget" do
     context "Gerbil squeak snuggle" do
       should "create the standard assets" do
-        
+
         run_generator %w(Gerbil squeak snuggle -t test_unit)
-        
+
         assert_file "app/widgets/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
         assert_file "app/widgets/gerbil_widget.rb", /def snuggle/
         assert_file "app/widgets/gerbil_widget.rb", /def squeak/
@@ -22,10 +22,17 @@ class WidgetGeneratorTest < Rails::Generators::TestCase
         assert_file "test/widgets/gerbil_widget_test.rb", %r(class GerbilWidgetTest < Apotomo::TestCase)
         assert_file "test/widgets/gerbil_widget_test.rb", %r(widget\(:gerbil\))
       end
-      
+
+      should "create javascript and css assets" do
+        run_generator %w(Gerbil squeak snuggle -t test_unit)
+
+        assert_file "app/assets/javascripts/widgets/gerbil_widget.coffee", /Define your coffeescript code for the Gerbil widget*/
+        assert_file "app/assets/stylesheets/widgets/gerbil_widget.css", /Define your css code for the Gerbil widget*/
+      end
+
       should "create haml assets with -e haml" do
         run_generator %w(Gerbil squeak snuggle -e haml -t test_unit)
-        
+
         assert_file "app/widgets/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
         assert_file "app/widgets/gerbil_widget.rb", /def snuggle/
         assert_file "app/widgets/gerbil_widget.rb", /def squeak/
@@ -37,7 +44,7 @@ class WidgetGeneratorTest < Rails::Generators::TestCase
 
       should "create slim assets with -e slim" do
         run_generator %w(Gerbil squeak snuggle -e slim -t test_unit)
-        
+
         assert_file "app/widgets/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
         assert_file "app/widgets/gerbil_widget.rb", /def snuggle/
         assert_file "app/widgets/gerbil_widget.rb", /def squeak/
@@ -46,7 +53,7 @@ class WidgetGeneratorTest < Rails::Generators::TestCase
         assert_file "app/widgets/gerbil/squeak.html.slim", %r(app/widgets/gerbil/squeak\.html\.slim)
         assert_file "test/widgets/gerbil_widget_test.rb"
       end
-      
+
       should "work with namespaces" do
         run_generator %w(Gerbil::Mouse squeak -t test_unit)
 
@@ -55,7 +62,7 @@ class WidgetGeneratorTest < Rails::Generators::TestCase
         assert_file "app/widgets/gerbil/mouse/squeak.html.erb", %r(app/widgets/gerbil/mouse/squeak\.html\.erb)
         assert_file "test/widgets/gerbil/mouse_widget_test.rb"
       end
-    
+
     end
   end
 end


### PR DESCRIPTION
Configure the widget generator to create both js and css files for Rails's assets pipeline.

It uses coffeescript and css, but I would like to make it use the right option according to the actual Rails configuration file (use sass, if the css framework is configured to use sass). I am not sure how to do that. Any idea?  
