### PR TITLE
explicitly ignore Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg/*
 .bundle
 test/dummy/log/*
 test/dummy/tmp/*
+Gemfile.lock


### PR DESCRIPTION
What do you think about explicitly ignoring Gemfile.lock?
