### PR TITLE
Correct the syntax. If you nest, then the first word of the nested block...

### DIFF
--- a/lib/generators/templates/view.slim
+++ b/lib/generators/templates/view.slim
@@ -1,2 +1,3 @@
-h1 <%= class_name %>Widget#<%= @state %>
-p Find me in <%= @path %>
+= widget_div do
+  h1 <%= class_name %>Widget#<%= @state %>
+  p Find me in <%= @path %>


### PR DESCRIPTION
Fixed some mistakes in the `.slim` template
