### PR TITLE
Reorganise where files are saved

### DIFF
--- a/lib/generators/apotomo/widget_generator.rb
+++ b/lib/generators/apotomo/widget_generator.rb
@@ -3,11 +3,22 @@ require 'generators/cells/base'
 module Apotomo
   module Generators
     module BasePathMethods
-    private
-      def base_path
-        File.join('app/widgets', class_path, file_name)
+      private
+        def base_path
+          File.join('app/widgets', class_path, file_name)
+        end
+    end
+    
+    module Views
+      def create_views
+        for state in actions do
+          @state  = state
+          @path   = File.join(base_path, 'views', "#{state}.html.#{handler}")  #base_path defined in Cells::Generators::Base.
+          template "view.#{handler}", @path
+        end
       end
     end
+        
     
     class WidgetGenerator < ::Cells::Generators::Base
       include BasePathMethods
@@ -21,7 +32,7 @@ module Apotomo
       
       
       def create_cell_file
-        template 'widget.rb', "#{base_path}_widget.rb"
+        template 'widget.rb', File.join('app/widgets', class_path, file_name, "#{file_name}_widget.rb")
       end
     end
   end

--- a/lib/generators/erb/widget_generator.rb
+++ b/lib/generators/erb/widget_generator.rb
@@ -5,6 +5,7 @@ module Erb
   module Generators
     class WidgetGenerator < CellGenerator
       include ::Apotomo::Generators::BasePathMethods
+      include ::Apotomo::Generators::Views
       source_root File.expand_path('../../templates', __FILE__)
     end
   end

--- a/lib/generators/haml/widget_generator.rb
+++ b/lib/generators/haml/widget_generator.rb
@@ -5,6 +5,7 @@ module Haml
   module Generators
     class WidgetGenerator < CellGenerator
       include ::Apotomo::Generators::BasePathMethods
+      include ::Apotomo::Generators::Views
       source_root File.expand_path('../../templates', __FILE__)
     end
   end

--- a/lib/generators/slim/widget_generator.rb
+++ b/lib/generators/slim/widget_generator.rb
@@ -5,6 +5,7 @@ module Slim
   module Generators
     class WidgetGenerator < CellGenerator
       include ::Apotomo::Generators::BasePathMethods
+      include ::Apotomo::Generators::Views
       source_root File.expand_path('../../templates', __FILE__)
     end
   end

--- a/test/rails/widget_generator_test.rb
+++ b/test/rails/widget_generator_test.rb
@@ -12,12 +12,13 @@ class WidgetGeneratorTest < Rails::Generators::TestCase
         
         run_generator %w(Gerbil squeak snuggle -t test_unit)
         
-        assert_file "app/widgets/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
-        assert_file "app/widgets/gerbil_widget.rb", /def snuggle/
-        assert_file "app/widgets/gerbil_widget.rb", /def squeak/
-        assert_file "app/widgets/gerbil/snuggle.html.erb", %r(app/widgets/gerbil/snuggle\.html\.erb)
-        assert_file "app/widgets/gerbil/snuggle.html.erb", %r(<p>)
-        assert_file "app/widgets/gerbil/squeak.html.erb", %r(app/widgets/gerbil/squeak\.html\.erb)
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /def snuggle/
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /def squeak/
+        
+        assert_file "app/widgets/gerbil/views/snuggle.html.erb", %r(app/widgets/gerbil/views/snuggle\.html\.erb)
+        assert_file "app/widgets/gerbil/views/snuggle.html.erb", %r(<p>)
+        assert_file "app/widgets/gerbil/views/squeak.html.erb", %r(app/widgets/gerbil/views/squeak\.html\.erb)
 
         assert_file "test/widgets/gerbil_widget_test.rb", %r(class GerbilWidgetTest < Apotomo::TestCase)
         assert_file "test/widgets/gerbil_widget_test.rb", %r(widget\(:gerbil\))
@@ -26,33 +27,39 @@ class WidgetGeneratorTest < Rails::Generators::TestCase
       should "create haml assets with -e haml" do
         run_generator %w(Gerbil squeak snuggle -e haml -t test_unit)
         
-        assert_file "app/widgets/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
-        assert_file "app/widgets/gerbil_widget.rb", /def snuggle/
-        assert_file "app/widgets/gerbil_widget.rb", /def squeak/
-        assert_file "app/widgets/gerbil/snuggle.html.haml", %r(app/widgets/gerbil/snuggle\.html\.haml)
-        assert_file "app/widgets/gerbil/snuggle.html.haml", %r(%p)
-        assert_file "app/widgets/gerbil/squeak.html.haml", %r(app/widgets/gerbil/squeak\.html\.haml)
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /def snuggle/
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /def squeak/
+        
+        assert_file "app/widgets/gerbil/views/snuggle.html.haml", %r(app/widgets/gerbil/views/snuggle\.html\.haml)
+        assert_file "app/widgets/gerbil/views/snuggle.html.haml", %r(%p)
+        assert_file "app/widgets/gerbil/views/squeak.html.haml", %r(app/widgets/gerbil/views/squeak\.html\.haml)
+        
         assert_file "test/widgets/gerbil_widget_test.rb"
       end
-
+      
       should "create slim assets with -e slim" do
         run_generator %w(Gerbil squeak snuggle -e slim -t test_unit)
         
-        assert_file "app/widgets/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
-        assert_file "app/widgets/gerbil_widget.rb", /def snuggle/
-        assert_file "app/widgets/gerbil_widget.rb", /def squeak/
-        assert_file "app/widgets/gerbil/snuggle.html.slim", %r(app/widgets/gerbil/snuggle\.html\.slim)
-        assert_file "app/widgets/gerbil/snuggle.html.slim", %r(p)
-        assert_file "app/widgets/gerbil/squeak.html.slim", %r(app/widgets/gerbil/squeak\.html\.slim)
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /class GerbilWidget < Apotomo::Widget/
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /def snuggle/
+        assert_file "app/widgets/gerbil/gerbil_widget.rb", /def squeak/
+        
+        assert_file "app/widgets/gerbil/views/snuggle.html.slim", %r(app/widgets/gerbil/views/snuggle\.html\.slim)
+        assert_file "app/widgets/gerbil/views/snuggle.html.slim", %r(p)
+        assert_file "app/widgets/gerbil/views/squeak.html.slim", %r(app/widgets/gerbil/views/squeak\.html\.slim)
+        
         assert_file "test/widgets/gerbil_widget_test.rb"
       end
       
       should "work with namespaces" do
         run_generator %w(Gerbil::Mouse squeak -t test_unit)
-
-        assert_file "app/widgets/gerbil/mouse_widget.rb", /class Gerbil::MouseWidget < Apotomo::Widget/
-        assert_file "app/widgets/gerbil/mouse_widget.rb", /def squeak/
-        assert_file "app/widgets/gerbil/mouse/squeak.html.erb", %r(app/widgets/gerbil/mouse/squeak\.html\.erb)
+      
+        assert_file "app/widgets/gerbil/mouse/mouse_widget.rb", /class Gerbil::MouseWidget < Apotomo::Widget/
+        assert_file "app/widgets/gerbil/mouse/mouse_widget.rb", /def squeak/
+        
+        assert_file "app/widgets/gerbil/mouse/views/squeak.html.erb", %r(app/widgets/gerbil/mouse/views/squeak\.html\.erb)
+        
         assert_file "test/widgets/gerbil/mouse_widget_test.rb"
       end
     


### PR DESCRIPTION
Currently the generated files looks like this:

```
widgets/parent_widget.rb
widgets/parent/parent_view.html.slim

widgets/parent/child_widget.rb
widgets/parent/child/child_view.html.slim
```

So in the same folder, we find both view pages from the parent widget and widget code from the child widget. 

Unrelated information in the same folder == mess. 

I propose to change it to:

```
widgets/parent/parent_widget.rb
widgets/parent/views/parent_view.html.slim

widgets/parent/child/child_widget.rb
widgets/parent/child/views/child_view.html.slim
```
