### PR TITLE
Remove Apotomo::Widget#visible?

### DIFF
--- a/lib/apotomo/test_case.rb
+++ b/lib/apotomo/test_case.rb
@@ -24,8 +24,8 @@ module Apotomo
   #
   # For unit testing, you can grab an instance of your tested widget.
   #
-  #     it "should be visible" do
-  #       assert root['post-comments'].visible?
+  #     it "should not be root" do
+  #       assert !root['post-comments'].root?
   #     end
   #
   # See also in Cell::TestCase.

--- a/lib/apotomo/widget.rb
+++ b/lib/apotomo/widget.rb
@@ -51,9 +51,7 @@ module Apotomo
     #     end
     define_hook :after_initialize
     define_hook :has_widgets
-    
-    attr_writer :visible
-    
+        
     include TreeNode
     
     include Onfire
@@ -80,7 +78,6 @@ module Apotomo
       super(parent)  # TODO: do that as long as cells do need a parent_controller.
       @options      = options
       @name         = id
-      @visible      = true
       
       setup_tree_node(parent)
       
@@ -90,10 +87,6 @@ module Apotomo
     def parent_controller
       # i hope we'll get rid of any parent_controller dependency, soon.
       root? ? @parent_controller : root.parent_controller
-    end
-    
-    def visible?
-      @visible
     end
     
     # Invokes +state+ and hopefully returns the rendered content.

--- a/test/test_case_test.rb
+++ b/test/test_case_test.rb
@@ -33,12 +33,7 @@ class TestCaseTest < MiniTest::Spec
 
         assert_equal "Please setup a widget tree using has_widgets()", exc.message
       end
-
-      it "memorize root" do
-        @test.root.visible=false
-        assert_equal false, @test.root.visible?
-      end
-
+      
       it "respond to #render_widget" do
         assert_equal "<div id=\"mum\">burp!</div>\n", @test.render_widget('mum', :eat)
         assert_equal "<div id=\"mum\">burp!</div>\n", @test.last_invoke

--- a/test/widget_test.rb
+++ b/test/widget_test.rb
@@ -58,17 +58,6 @@ class WidgetTest < ActiveSupport::TestCase
       end
     end
 
-    describe "implementing visibility" do
-      it "per default respond to #visible?" do
-        assert @mum.visible?
-      end
-
-      it "expose a setter therefore" do
-        @mum.visible = false
-        assert_not @mum.visible?
-      end
-    end
-
     describe "#find_widget" do
       before do
         mum_and_kid!


### PR DESCRIPTION
`Apotomo::Widget#visible?` isn't used, it isn't documented.
It looks strange: there are more another useful flags, why we did this one?
It's simple to realize it by yourself.
Let's remove it...
