### PR TITLE
Removing the test_case require based on Rails.env == "test"

### DIFF
--- a/lib/apotomo.rb
+++ b/lib/apotomo.rb
@@ -4,9 +4,9 @@ module Apotomo
       @js_framework = js_framework
       @js_generator = JavascriptGenerator.new(js_framework)
     end
-    
+
     attr_reader :js_generator, :js_framework
-    
+
     # Apotomo setup/configuration helper for initializer.
     #
     # == Usage/Examples:
@@ -25,6 +25,5 @@ require 'apotomo/railtie'
 require 'apotomo/widget_shortcuts'
 require 'apotomo/rails/controller_methods'
 require 'apotomo/javascript_generator'
-require 'apotomo/test_case' if Rails.env == "test"
 
 Apotomo.js_framework = :jquery ### DISCUSS: move to rails.rb

--- a/lib/apotomo.rb
+++ b/lib/apotomo.rb
@@ -1,4 +1,6 @@
 module Apotomo
+  autoload :TestCase, 'apotomo/test_case'
+
   class << self
     def js_framework=(js_framework)
       @js_framework = js_framework


### PR DESCRIPTION
The test env doesn't means that the Apotomo test_case should be loaded.
Examples:

1. I'm running an app with rspec.
2. I'm testing my widgets without the provided test_case.

Leaving it for users that use the apotomo/test_case would be better, so they can require only if they need it.

WDYT? Thanks in advance, any feedback will be appreciated.