### PR TITLE
Fixed for Rails > 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .DS_Store
 pkg
 *.gem

--- a/lib/apotomo/rails/controller_methods.rb
+++ b/lib/apotomo/rails/controller_methods.rb
@@ -67,7 +67,7 @@ module Apotomo
 
         return render_iframe_updates(page_updates) if params[:apotomo_iframe]
 
-        render :text => page_updates.join("\n"), :content_type => Mime::JS
+        render :text => page_updates.join("\n"), :content_type => Mime['js']
       end
 
       # Returns the url to trigger a +type+ event from +:source+, which is a non-optional parameter.

--- a/lib/apotomo/rails/controller_methods.rb
+++ b/lib/apotomo/rails/controller_methods.rb
@@ -67,7 +67,7 @@ module Apotomo
 
         return render_iframe_updates(page_updates) if params[:apotomo_iframe]
 
-        render :text => page_updates.join("\n"), :content_type => Mime['js']
+        render plain: page_updates.join("\n"), :content_type => Mime[:js]
       end
 
       # Returns the url to trigger a +type+ event from +:source+, which is a non-optional parameter.


### PR DESCRIPTION
'Mime::JS' & 'render :text =>' are both deprecated in Rails 5.1, updating to the new syntax fixes the problems.